### PR TITLE
Changed export order

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "author": "Muspi Merol <me@promplate.dev>",
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./options": {
-      "default": "./dist/options.js",
-      "types": "./dist/options.d.ts"
+      "types": "./dist/options.d.ts",
+      "default": "./dist/options.js"
     }
   },
   "main": "dist/index.js",


### PR DESCRIPTION
Hey, this is known issue on next.js, which requires to default export to be in the end.
Same was [here](https://github.com/firebase/firebase-js-sdk/pull/7007/files)