### PR TITLE
fix: preserve __proto__ as an object key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,12 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 index++; // skip colon
                 try {
                     const value = parseAny();
-                    obj[key] = value;
+                    Object.defineProperty(obj, key, {
+                        value,
+                        writable: true,
+                        enumerable: true,
+                        configurable: true,
+                    });
                 } catch (e) {
                     if (Allow.OBJ & allow) return obj;
                     else throw e;

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,12 +106,16 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 index++; // skip colon
                 try {
                     const value = parseAny();
-                    Object.defineProperty(obj, key, {
-                        value,
-                        writable: true,
-                        enumerable: true,
-                        configurable: true,
-                    });
+                    if (key === "__proto__") {
+                        Object.defineProperty(obj, key, {
+                            value,
+                            writable: true,
+                            enumerable: true,
+                            configurable: true,
+                        });
+                    } else {
+                        obj[key] = value;
+                    }
                 } catch (e) {
                     if (Allow.OBJ & allow) return obj;
                     else throw e;

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -22,6 +22,13 @@ test("obj", () => {
     expect(parse('{"": "', OBJ)).toEqual({});
     expect(parse('{"": "', OBJ | STR)).toEqual({ "": "" });
 
+    const protoValue = { polluted: true };
+    const parsed = parse('{"__proto__":{"polluted":true},"safe":1}');
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+    expect(parsed.__proto__).toEqual(protoValue);
+    expect(parsed.safe).toBe(1);
+    expect(Object.prototype.polluted).toBeUndefined();
+
     expect(() => parse("{", STR)).toThrow(PartialJSON);
     expect(() => parse('{"', STR)).toThrow(PartialJSON);
     expect(() => parse('{""', STR)).toThrow(PartialJSON);

--- a/tests/examples.test.js
+++ b/tests/examples.test.js
@@ -29,6 +29,25 @@ test("obj", () => {
     expect(parsed.safe).toBe(1);
     expect(Object.prototype.polluted).toBeUndefined();
 
+    const parsedPrimitive = parse('{"__proto__":1,"safe":1}');
+    expect(Object.prototype.hasOwnProperty.call(parsedPrimitive, "__proto__")).toBe(true);
+    expect(parsedPrimitive.__proto__).toBe(1);
+    expect(parsedPrimitive.safe).toBe(1);
+    expect(Object.prototype.polluted).toBeUndefined();
+
+    const nested = parse('{"child":{"__proto__":{"polluted":true}},"items":[{"__proto__":1}]}');
+    expect(Object.prototype.hasOwnProperty.call(nested.child, "__proto__")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(nested.items[0], "__proto__")).toBe(true);
+    expect(nested.child.__proto__).toEqual(protoValue);
+    expect(nested.items[0].__proto__).toBe(1);
+    expect(Object.prototype.polluted).toBeUndefined();
+
+    const parsedWithFlags = parse('{"__proto__":{"polluted":true},"safe":1}', OBJ | STR);
+    expect(Object.prototype.hasOwnProperty.call(parsedWithFlags, "__proto__")).toBe(true);
+    expect(parsedWithFlags.__proto__).toEqual(protoValue);
+    expect(parsedWithFlags.safe).toBe(1);
+    expect(Object.prototype.polluted).toBeUndefined();
+
     expect(() => parse("{", STR)).toThrow(PartialJSON);
     expect(() => parse('{"', STR)).toThrow(PartialJSON);
     expect(() => parse('{""', STR)).toThrow(PartialJSON);


### PR DESCRIPTION
Fixes #8

This keeps `__proto__` as a normal parsed object key by defining parsed members as own data properties instead of assigning through bracket syntax. I also added a regression check for the edge case.

Checks:
- `git diff --check`

I could not run the JS build/tests locally because `tsc` and `vitest` are not installed in this checkout.