### PR TITLE
fix: remove invalid module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Fixes #16

The package currently builds CommonJS output only, so `module` points at the same CommonJS file as `main`. This removes the `module` field so bundlers do not treat `dist/index.js` as an ES module entry.

Checks:
- `git diff --check`
- `node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8")); console.log("package.json ok")'`