### PR TITLE
fix: distinguish malformed documents from incomplete json

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,11 +6,19 @@ describe("malformed JSON handling", () => {
         expect(() => parse("[1, .05, 2]")).toThrow(MalformedJSON);
     });
 
+    it("throws for malformed numbers inside objects", () => {
+        expect(() => parse('{"a": .05, "b": 2}')).toThrow(MalformedJSON);
+    });
+
     it("keeps parsing after an empty array with spaces", () => {
         expect(parse('[{"id":1,"arr":["hello"]},{"id":2,"arr":[        ],"more":"yaya"},{"id":3,"arr":["!"]}]')).toEqual([
             { id: 1, arr: ["hello"] },
             { id: 2, arr: [], more: "yaya" },
             { id: 3, arr: ["!"] },
         ]);
+    });
+
+    it("keeps parsing after an object comma with spaces", () => {
+        expect(parse('{"a":1,   }')).toEqual({ a: 1 });
     });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -21,4 +21,8 @@ describe("malformed JSON handling", () => {
     it("keeps parsing after an object comma with spaces", () => {
         expect(parse('{"a":1,   }')).toEqual({ a: 1 });
     });
+
+    it("keeps parsing after an array comma with spaces", () => {
+        expect(parse("[1,   ]")).toEqual([1]);
+    });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { MalformedJSON, parse } from "./index";
+
+describe("malformed JSON handling", () => {
+    it("throws for malformed numbers inside arrays", () => {
+        expect(() => parse("[1, .05, 2]")).toThrow(MalformedJSON);
+    });
+
+    it("keeps parsing after an empty array with spaces", () => {
+        expect(parse('[{"id":1,"arr":["hello"]},{"id":2,"arr":[        ],"more":"yaya"},{"id":3,"arr":["!"]}]')).toEqual([
+            { id: 1, arr: ["hello"] },
+            { id: 2, arr: [], more: "yaya" },
+            { id: 3, arr: ["!"] },
+        ]);
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,10 +125,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 }
             }
         } catch (e) {
-            if (!isPartialJSON(e)) {
-                if (index >= length) markPartialJSON("Expected '}' at end of object");
-                throw e;
-            }
+            if (!isPartialJSON(e)) throw e;
             if (Allow.OBJ & allow) return obj;
             markPartialJSON("Expected '}' at end of object");
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,19 +165,24 @@ const _parseJSON = (jsonString: string, allow: number) => {
         const token = jsonString.substring(start, index);
         const atEnd = index === length;
 
-        if (start > 0 && atEnd && !(Allow.NUM & allow)) markPartialJSON("Unterminated number literal");
-
+        let value;
         try {
-            return JSON.parse(token);
+            value = JSON.parse(token);
         } catch (e) {
             if (token === "-" && atEnd && start > 0) markPartialJSON("Not sure what '-' is");
-            if (atEnd && Allow.NUM & allow) {
+            if (atEnd) {
                 const partial = token.match(/^(-?(?:0|[1-9]\d*)(?:\.\d+)?)[eE][+-]?$/)
                     ?? token.match(/^(-?(?:0|[1-9]\d*))\.$/);
-                if (partial) return JSON.parse(partial[1]);
+                if (partial) {
+                    if (Allow.NUM & allow) return JSON.parse(partial[1]);
+                    if (start > 0) markPartialJSON("Unterminated number literal");
+                }
             }
             throwMalformedError(String(e));
         }
+        // Only valid numeric tokens can be incomplete streaming numbers.
+        if (start > 0 && atEnd && !(Allow.NUM & allow)) markPartialJSON("Unterminated number literal");
+        return value;
     };
 
     const skipBlank = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,14 +114,15 @@ const _parseJSON = (jsonString: string, allow: number) => {
                     throw e;
                 }
                 skipBlank();
-                if (jsonString[index] === ",") index++; // skip comma
+                if (jsonString[index] === ",") {
+                    index++; // skip comma
+                    skipBlank();
+                }
             }
         } catch (e) {
-            if (isPartialJSON(e)) {
-                if (Allow.OBJ & allow) return obj;
-                markPartialJSON("Expected '}' at end of object");
-            }
-            throw e;
+            if (!isPartialJSON(e)) throw e;
+            if (Allow.OBJ & allow) return obj;
+            markPartialJSON("Expected '}' at end of object");
         }
         index++; // skip final brace
         return obj;
@@ -141,13 +142,11 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 }
             }
         } catch (e) {
-            if (isPartialJSON(e)) {
-                if (Allow.ARR & allow) {
-                    return arr;
-                }
-                markPartialJSON("Expected ']' at end of array");
+            if (!isPartialJSON(e)) throw e;
+            if (Allow.ARR & allow) {
+                return arr;
             }
-            throw e;
+            markPartialJSON("Expected ']' at end of array");
         }
         index++; // skip final bracket
         return arr;

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,10 @@ const _parseJSON = (jsonString: string, allow: number) => {
             index++;
         }
     };
-    return parseAny();
+    const value = parseAny();
+    skipBlank();
+    if (index < length) throwMalformedError("Unexpected content after JSON value");
+    return value;
 };
 
 const parse = parseJSON;

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,35 +156,23 @@ const _parseJSON = (jsonString: string, allow: number) => {
     };
 
     const parseNum = () => {
-        if (index === 0) {
-            if (jsonString === "-") throwMalformedError("Not sure what '-' is");
-            try {
-                return JSON.parse(jsonString);
-            } catch (e) {
-                if (Allow.NUM & allow)
-                    try {
-                        return JSON.parse(jsonString.substring(0, jsonString.lastIndexOf("e")));
-                    } catch (e) {}
-                throwMalformedError(String(e));
-            }
-        }
-
         const start = index;
+        while (index < length && !",]} \n\r\t".includes(jsonString[index])) index++;
+        const token = jsonString.substring(start, index);
+        const atEnd = index === length;
 
-        if (jsonString[index] === "-") index++;
-        while (jsonString[index] && ",]}".indexOf(jsonString[index]) === -1) index++;
-
-        if (index == length && !(Allow.NUM & allow)) markPartialJSON("Unterminated number literal");
+        if (start > 0 && atEnd && !(Allow.NUM & allow)) markPartialJSON("Unterminated number literal");
 
         try {
-            return JSON.parse(jsonString.substring(start, index));
+            return JSON.parse(token);
         } catch (e) {
-            if (jsonString.substring(start, index) === "-") markPartialJSON("Not sure what '-' is");
-            try {
-                return JSON.parse(jsonString.substring(start, jsonString.lastIndexOf("e")));
-            } catch (e) {
-                throwMalformedError(String(e));
+            if (token === "-" && atEnd && start > 0) markPartialJSON("Not sure what '-' is");
+            if (atEnd && Allow.NUM & allow) {
+                const partial = token.match(/^(-?(?:0|[1-9]\d*)(?:\.\d+)?)[eE][+-]?$/)
+                    ?? token.match(/^(-?(?:0|[1-9]\d*))\.$/);
+                if (partial) return JSON.parse(partial[1]);
             }
+            throwMalformedError(String(e));
         }
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,9 +102,12 @@ const _parseJSON = (jsonString: string, allow: number) => {
         try {
             while (jsonString[index] !== "}") {
                 skipBlank();
-                if (index >= length && Allow.OBJ & allow) return obj;
+                if (index >= length) markPartialJSON("Expected an object key");
+                if (jsonString[index] !== '"') throwMalformedError("Expected a quoted object key");
                 const key = parseStr();
                 skipBlank();
+                if (index >= length) markPartialJSON("Expected ':' after object key");
+                if (jsonString[index] !== ":") throwMalformedError("Expected ':' after object key");
                 index++; // skip colon
                 try {
                     const value = parseAny();
@@ -117,6 +120,8 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 if (jsonString[index] === ",") {
                     index++; // skip comma
                     skipBlank();
+                } else if (index < length && jsonString[index] !== "}") {
+                    throwMalformedError("Expected ',' or '}' after object value");
                 }
             }
         } catch (e) {
@@ -142,6 +147,8 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 if (jsonString[index] === ",") {
                     index++; // skip comma
                     skipBlank();
+                } else if (index < length && jsonString[index] !== "]") {
+                    throwMalformedError("Expected ',' or ']' after array value");
                 }
             }
         } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ const _parseJSON = (jsonString: string, allow: number) => {
         throw new MalformedJSON(`${msg} at position ${index}`);
     };
 
+    const isPartialJSON = (e: unknown) => e instanceof PartialJSON;
+
     const parseAny: () => any = () => {
         skipBlank();
         if (index >= length) markPartialJSON("Unexpected end of input");
@@ -108,15 +110,18 @@ const _parseJSON = (jsonString: string, allow: number) => {
                     const value = parseAny();
                     obj[key] = value;
                 } catch (e) {
-                    if (Allow.OBJ & allow) return obj;
-                    else throw e;
+                    if (Allow.OBJ & allow && isPartialJSON(e)) return obj;
+                    throw e;
                 }
                 skipBlank();
                 if (jsonString[index] === ",") index++; // skip comma
             }
         } catch (e) {
-            if (Allow.OBJ & allow) return obj;
-            else markPartialJSON("Expected '}' at end of object");
+            if (isPartialJSON(e)) {
+                if (Allow.OBJ & allow) return obj;
+                markPartialJSON("Expected '}' at end of object");
+            }
+            throw e;
         }
         index++; // skip final brace
         return obj;
@@ -124,6 +129,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
 
     const parseArr = () => {
         index++; // skip initial bracket
+        skipBlank();
         const arr = [];
         try {
             while (jsonString[index] !== "]") {
@@ -131,13 +137,17 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 skipBlank();
                 if (jsonString[index] === ",") {
                     index++; // skip comma
+                    skipBlank();
                 }
             }
         } catch (e) {
-            if (Allow.ARR & allow) {
-                return arr;
+            if (isPartialJSON(e)) {
+                if (Allow.ARR & allow) {
+                    return arr;
+                }
+                markPartialJSON("Expected ']' at end of array");
             }
-            markPartialJSON("Expected ']' at end of array");
+            throw e;
         }
         index++; // skip final bracket
         return arr;

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,10 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 }
             }
         } catch (e) {
-            if (!isPartialJSON(e)) throw e;
+            if (!isPartialJSON(e)) {
+                if (index >= length) markPartialJSON("Expected '}' at end of object");
+                throw e;
+            }
             if (Allow.OBJ & allow) return obj;
             markPartialJSON("Expected '}' at end of object");
         }

--- a/src/number-regressions.test.ts
+++ b/src/number-regressions.test.ts
@@ -10,6 +10,7 @@ describe("partial number suffixes", () => {
     it.each(["1evil", "1e+oops", "01e", "1.e", "1e2e"])("rejects malformed exponent text: %s", (input) => {
         expect(() => parse(input)).toThrow(MalformedJSON);
         expect(() => parse(`[${input}]`)).toThrow(MalformedJSON);
+        expect(() => parse(`{"value":${input}`)).toThrow(MalformedJSON);
     });
     it.each(["[1e,2]", "[1.,2]", "[1E+]", '[1e+2junk]'])("does not repair numbers terminated by a delimiter: %s", (input) => {
         expect(() => parse(input)).toThrow(MalformedJSON);

--- a/src/number-regressions.test.ts
+++ b/src/number-regressions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { Allow, MalformedJSON, parse } from "./index";
+
+describe("partial number suffixes", () => {
+    it.each(["123.", "123e", "123E", "123e+", "123E-", "-123."])("completes only a valid unfinished suffix: %s", (input) => {
+        const expected = input.startsWith("-") ? -123 : 123;
+        expect(parse(input)).toBe(expected);
+        expect(parse(`[${input}`)).toEqual([expected]);
+    });
+    it.each(["1evil", "1e+oops", "01e", "1.e", "1e2e"])("rejects malformed exponent text: %s", (input) => {
+        expect(() => parse(input)).toThrow(MalformedJSON);
+        expect(() => parse(`[${input}]`)).toThrow(MalformedJSON);
+    });
+    it.each(["[1e,2]", "[1.,2]", "[1E+]", '[1e+2junk]'])("does not repair numbers terminated by a delimiter: %s", (input) => {
+        expect(() => parse(input)).toThrow(MalformedJSON);
+    });
+    it("keeps complete numbers and the partial-number opt-out", () => {
+        expect(parse("-1.25E+2", 0)).toBe(-125);
+        expect(parse("[1.25", Allow.ARR)).toEqual([]);
+    });
+});

--- a/src/separator-regressions.test.ts
+++ b/src/separator-regressions.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { Allow, MalformedJSON, PartialJSON, parse } from "./index";
+
+describe("object and array separators", () => {
+    it.each(['{"a" 1}', '{"a"::1}', '{foo:1}', '[true false]', '["a" "b"]', '[1 2]', '{"a":1 "b":2}', '[{},{} {}]'])("rejects a missing separator or unquoted key: %s", (input) => {
+        expect(() => parse(input)).toThrow(MalformedJSON);
+    });
+    it.each(['{', '{"a"', '{"a":'])("still recovers unfinished object prefixes: %s", (input) => {
+        expect(parse(input)).toEqual({});
+        expect(() => parse(input, 0)).toThrow(PartialJSON);
+    });
+    it("retains valid nesting and permitted incomplete containers", () => {
+        expect(parse('{"a":[1,true,{"b":"c"}]}')).toEqual({a:[1,true,{b:"c"}]});
+        expect(parse('{"a":1')).toEqual({a:1});
+        expect(parse('[1,2', Allow.ARR | Allow.NUM)).toEqual([1,2]);
+    });
+});

--- a/src/strict-number-classification.test.ts
+++ b/src/strict-number-classification.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from "vitest";
+import { Allow, MalformedJSON, parse } from "./index";
+
+it.each(["[oops", "[01", "[1evil"])("rejects malformed array numbers with NUM disabled: %s", (input) => {
+    expect(() => parse(input, Allow.ARR)).toThrow(MalformedJSON);
+});
+it.each(['{"value":oops', '{"value":01', '{"value":1evil'])("rejects malformed object numbers with NUM disabled: %s", (input) => {
+    expect(() => parse(input, Allow.OBJ)).toThrow(MalformedJSON);
+});
+it("preserves strict root whitespace and streaming numeric opt-out", () => {
+    expect(parse(" 1", 0)).toBe(1);
+    expect(parse("\n-1.5\t", 0)).toBe(-1.5);
+    expect(parse("[1.25", Allow.ARR)).toEqual([]);
+    expect(parse("[1e+", Allow.ARR)).toEqual([]);
+});

--- a/src/trailing-content.test.ts
+++ b/src/trailing-content.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { MalformedJSON, parse } from "./index";
+
+describe("complete document boundary", () => {
+    it.each(['true false', 'null garbage', '"hello" "world"', '{} []', '[] trailing', 'Infinityx', 'NaNtail'])("rejects content after the first value: %s", (input) => {
+        expect(() => parse(input)).toThrow(MalformedJSON);
+    });
+    it.each(['true', 'null', '"hello"', '{}', '[]', '123', '-1.5e2'])("accepts trailing whitespace: %s", (input) => {
+        expect(parse(`${input} \n\t`)).toEqual(JSON.parse(input));
+    });
+    it("still accepts incomplete atoms and containers", () => {
+        expect(parse('tr')).toBe(true);
+        expect(parse('Inf')).toBe(Infinity);
+        expect(parse('1e+')).toBe(1);
+        expect(parse('[1,')).toEqual([1]);
+        expect(parse('{"a":')).toEqual({});
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,11 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true
-  }
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
Fixes #12 by preserving malformed-input errors instead of silently returning a partial collection.

The final change also covers related malformed-input paths discovered during regression testing:
- Only valid unfinished numeric suffixes at EOF are completed, including decimal points and uppercase/lowercase exponents. Text such as `1evil` or a delimited `[1e,2]` is rejected.
- Numeric tokens are validated before applying the partial-number opt-out; malformed tokens are rejected even with only Allow.ARR or Allow.OBJ enabled. Six regressions cover this, while valid unfinished numbers still obey the opt-out.
- Malformed values remain malformed even when an enclosing object reaches EOF; five nested-number regressions cover this classification.
- Objects require quoted keys and colons; arrays and objects require separators between values.
- Non-whitespace content after the first complete JSON value is rejected.
- Vitest source files are excluded from the library build so `tsc` does not emit test code or pull test-runner declarations into the CommonJS build.

Existing examples for incomplete collections, partial-type flags, permissive unfinished-string recovery, and trailing-comma handling remain passing. The separate prototype-key PR #20 and package metadata PR #21 are not duplicated here.

Validation on the current branch:
- `npm run build` passes.
- `npm test -- --run` passes: **6 files, 61 tests**.
- `git diff --check` passes.
- New regression groups failed before the corresponding fixes: 9 numeric cases, missing-separator cases, and 7 trailing-content cases. The tests include valid/incomplete inputs to protect existing behavior.

Prepared with AI assistance; the build and tests were run locally. No model calls or network requests occur in the parser tests.
