### PR TITLE
fix: preserve __proto__ object keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,11 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 index++; // skip colon
                 try {
                     const value = parseAny();
-                    Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
+                    if (key === "__proto__") {
+                        Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
+                    } else {
+                        obj[key] = value;
+                    }
                 } catch (e) {
                     if (Allow.OBJ & allow) return obj;
                     else throw e;

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
                 index++; // skip colon
                 try {
                     const value = parseAny();
-                    obj[key] = value;
+                    Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
                 } catch (e) {
                     if (Allow.OBJ & allow) return obj;
                     else throw e;

--- a/src/proto.test.ts
+++ b/src/proto.test.ts
@@ -4,8 +4,13 @@ import { parse } from "./index";
 describe("object key parsing", () => {
     it("preserves __proto__ as an own enumerable key", () => {
         const value = parse('{"__proto__":0}');
+        const descriptor = Object.getOwnPropertyDescriptor(value, "__proto__");
 
-        expect(value).toEqual({ __proto__: 0 });
-        expect(Object.prototype.hasOwnProperty.call(value, "__proto__")).toBe(true);
+        expect(descriptor).toMatchObject({
+            value: 0,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+        });
     });
 });

--- a/src/proto.test.ts
+++ b/src/proto.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "./index";
+
+describe("object key parsing", () => {
+    it("preserves __proto__ as an own enumerable key", () => {
+        const value = parse('{"__proto__":0}');
+
+        expect(value).toEqual({ __proto__: 0 });
+        expect(Object.prototype.hasOwnProperty.call(value, "__proto__")).toBe(true);
+    });
+});


### PR DESCRIPTION
Fixes #8

This keeps `"__proto__"` as an own enumerable property instead of assigning through the prototype setter. I added a focused Vitest regression for `parse('{"__proto__":0}')`.

I couldn’t run the suite locally here, so CI is the check.