### PR TITLE
fix: remove incorrect module entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     }
   },
   "main": "dist/index.js",
-  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Fixes #16

`dist/index.js` is CommonJS, so advertising it through the `module` field makes tools treat the same file as an ES module entry. This removes the incorrect field and leaves consumers on the existing CommonJS `main`/`exports` path.

I couldn’t run the package checks locally here, so CI is the check.