### PR TITLE
docs: clarify parsing fenced model output

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ console.log(result); // Outputs: -Infinity
 `parse` expects the JSON text itself. If a model wraps JSON in Markdown fences or surrounding prose, strip that wrapper before passing the string to `parse`:
 
 ````js
-const reply = "```json\n{\"status\": \"ok\"}\n```";
-const json = reply.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+const reply = "Here is the JSON:\n```json\n{\"status\": \"ok\"}\n```";
+const match = reply.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+const json = match ? match[1] : reply;
 
 parse(json); // Outputs: { status: "ok" }
 ````

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ result = parse("-Inf");
 console.log(result); // Outputs: -Infinity
 ```
 
+### Parsing model replies with Markdown fences
+
+`parse` expects the JSON text itself. If a model wraps JSON in Markdown fences or surrounding prose, strip that wrapper before passing the string to `parse`:
+
+````js
+const reply = "```json\n{\"status\": \"ok\"}\n```";
+const json = reply.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+
+parse(json); // Outputs: { status: "ok" }
+````
+
 ### Handling malformed JSON
 
 If the JSON string is malformed, the `parse` function will throw an error:


### PR DESCRIPTION
Adds a short README note for model replies that wrap JSON in Markdown fences or surrounding prose.

This keeps parser behavior unchanged and points users to strip the wrapper before calling `parse`.

Closes #10